### PR TITLE
Add adjust_ocr_pgnums.py and fix process_volume summary line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,25 @@ the per-run logs in `workspace/logs/`.
   pad-width from the first tif header so it isn't volume-specific. Reads input read-only, writes
   a `-fixed` copy. `-s` sets the start page, `-m` adds marker strings, `-n` dry-runs. Fixing the
   OCR page numbers is the upstream fix for the drift `diagnose_log.py` surfaces, since
-  `insert_milestones` keys milestone numbers off the OCR page numbers.
-- `adjust_pg_nums.py` — shifts page/line milestone numbers in a range within a doc.
+  `insert_milestones` keys milestone numbers off the OCR page numbers. Use this for an
+  *absolute* renumber (discard the old numbers, stamp a fresh contiguous run from `-s` to EOF);
+  use `adjust_ocr_pgnums.py` (below) for a *relative* shift that keeps the old numbers.
+- `adjust_ocr_pgnums.py` — the OCR-header analog of `adjust_pg_nums.py`: adds `-d/--delta`
+  (may be negative) to the image number of every `out_NNNN.tif` header whose current number is
+  in the `[-s, -e]` range, rewriting the volume in place. Builds the file name from `-v`
+  (`kama-vol-NNN.txt`) and looks it up in the OCR dir (`-p` overrides; default matches
+  `insert_milestones.py`'s `ocrfolder`). The range is keyed on the headers' *existing* numbers,
+  not their position, so `-s 601` means "start at the header currently numbered `out_0601.tif`";
+  omit `-s`/`-e` for first/last. Unlike `renumber_ocr_pages.py` it preserves the numbers and only
+  slides the selected window (intentional gaps outside the range survive), so it's for "a splice
+  upstream left everything from page N off by a constant". Backs up to `-bak` (timestamped if a
+  backup already exists) before writing; `-n` dry-runs; warns (doesn't block) if the shift leaves
+  duplicate header numbers, and refuses a delta that would make a number negative. A header whose
+  number part isn't all digits (e.g. `out_XXXX.tif`) is treated as a *placeholder* for a page
+  awaiting its real number: it's skipped by the shift (so an unbounded `-s N` won't disturb it —
+  no need to bound with `-e`) and reported as a reminder to rename it by hand afterward.
+- `adjust_pg_nums.py` — shifts page/line milestone numbers in a range within a styled `.docx`
+  (the `[p.l]` milestones, not OCR headers; `adjust_ocr_pgnums.py` is the OCR-side counterpart).
 - `split_into_texts_delim.py` / `split_into_text_spread.py` — split a volume into texts on
   a delimiter (the README notes this approach is unreliable).
 - Other top-level scripts (`check_for_missing.py`, `find-bad-vol-pages.py`,

--- a/README.md
+++ b/README.md
@@ -137,6 +137,36 @@ the changes. It reads the input read-only and writes a `-fixed` copy alongside i
 corrected stretch back into the main OCR volume, then rerun `process_volume.py` (forward `-c` to
 `insert_milestones.py` to restore the original Word docs from `workspace/in/bak` and reconvert).
 
+### Shifting a range of OCR page numbers with `adjust_ocr_pgnums.py`
+
+`renumber_ocr_pages.py` throws the old numbers away and stamps a fresh contiguous sequence, which
+is what you want after a messy hand-edit. When the fix is simpler — a single splice or deletion
+upstream has left **every** header from some page on off by a constant amount — you often just want
+to slide a range up or down without renumbering the whole file. `adjust_ocr_pgnums.py` does that:
+
+```
+python adjust_ocr_pgnums.py -v 67 -d 1 -s 601        # +1 to out_0601.tif through the end
+python adjust_ocr_pgnums.py -v 67 -d -2 -s 601 -e 650 # -2 to out_0601.tif .. out_0650.tif
+python adjust_ocr_pgnums.py -v 67 -d 1 -s 601 -n      # dry run, just report the changes
+```
+
+It builds the file name from the volume number (`-v 67` → `kama-vol-067.txt`) and finds it in the
+OCR directory (`-p` overrides the default). `-d/--delta` is the amount to add (negative to
+subtract). The `-s`/`-e` range is matched against the headers' **existing** image numbers, so
+`-s 601` means "start at the header currently numbered `out_0601.tif`"; omit `-s` to begin at the
+first page and `-e` to run through the last. It backs the volume up to a `-bak` copy (timestamped
+if one already exists) before editing in place, dry-runs with `-n`, and warns if the shift would
+leave two headers with the same number (a sign the range boundary overlaps pages it shouldn't).
+This is the OCR-header counterpart of `adjust_pg_nums.py`, which shifts the `[p.l]` milestones
+inside an already-styled Word doc.
+
+When you splice a missing page in, give it a **non-numeric placeholder header** like
+`tbocrtifs/kama_vol_067/out_XXXX.tif` instead of a real number. The shift ignores any header whose
+number part isn't all digits, so an unbounded `-s 360` slides everything from 360 to the end up by
+one *without* disturbing the placeholder — no `-e` needed to protect it. The script reports the
+ignored placeholder as a reminder; once the surrounding pages are renumbered, rename the
+placeholder by hand to the number that now fits the gap.
+
 ## Overall Process for Conversion of Sambhota Files
 
 The conversion process is a multi-stepped process that requires both a Mac and a Windows machine to proceed 

--- a/adjust_ocr_pgnums.py
+++ b/adjust_ocr_pgnums.py
@@ -1,0 +1,169 @@
+"""
+Shift the page-header image numbers in a plain-text OCR volume by a fixed delta
+over a range of pages. The OCR-header analog of ``adjust_pg_nums.py`` (which does
+the same thing to ``[p.l]`` milestones inside a styled Word doc).
+
+OCR volumes are plain text where each scanned page begins with a header line like
+
+    tbocrtifs/kama_vol_067/out_0601.tif
+
+followed by that page's lines. When a scan is spliced in or removed upstream, every
+header from that point on ends up off by a constant amount. This script adds ``--delta``
+(which may be negative) to the image number of every ``out_NNNN.tif`` header whose
+current number falls in the ``[--start, --end]`` range, rewriting the file in place.
+
+It keys the range on the headers' *existing* numbers (not their position), so ``-s 601``
+means "start at the header currently numbered ``out_0601.tif``". Omit ``--start`` to begin
+at the first page and ``--end`` to run through the last. Unlike ``renumber_ocr_pages.py``
+-- which discards the old numbers and stamps a fresh contiguous sequence -- this preserves
+the existing numbers and only slides the selected window, so any intentional gaps outside
+the range are left untouched.
+
+The volume file name is built from the volume number (``kama-vol-NNN.txt``) and looked up
+in the OCR directory. The original is backed up (``-bak`` before the extension) before any
+change, in case something goes wrong.
+
+Usage:
+    python adjust_ocr_pgnums.py -v 67 -d 1 -s 601        # +1 to out_0601.tif .. end
+    python adjust_ocr_pgnums.py -v 67 -d -2 -s 601 -e 650
+    python adjust_ocr_pgnums.py -v 67 -d 1               # +1 to every header
+    python adjust_ocr_pgnums.py -v 67 -d 1 -s 601 -n     # dry run, just report
+"""
+import argparse
+import datetime
+import os
+import re
+import shutil
+import sys
+
+# Where the plain-text OCR volumes live (matches insert_milestones.py's ocrfolder).
+DEFAULT_OCR_DIR = '/Users/ndg8f/Sandbox/THL/Catalogs/Kama/ocr-plain'
+# Capture the prefix (through out_), the digits, and the suffix of a tif header.
+TIF_RE = re.compile(r'^(.*out_)(\d+)(\.tif)\s*$')
+# A header line whose number part isn't all digits (e.g. out_XXXX.tif) -- a hand
+# placeholder for a page still awaiting its real number. Ignored by the shift (no
+# --end needed to protect it) but reported so it isn't forgotten.
+PLACEHOLDER_RE = re.compile(r'^.*out_\S*\.tif\s*$')
+
+
+def backup_path(filepath):
+    """Return a ``-bak`` path for filepath, timestamped if a backup already exists
+    so a rerun never clobbers an earlier good backup."""
+    root, ext = os.path.splitext(filepath)
+    bak = root + '-bak' + ext
+    if os.path.exists(bak):
+        stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+        bak = "{}-bak-{}{}".format(root, stamp, ext)
+    return bak
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Shift OCR page-header image numbers by a delta over a range.')
+    parser.add_argument('-v', '--vol', required=True,
+                        help='Volume number; the file kama-vol-NNN.txt is built from it')
+    parser.add_argument('-d', '--delta', required=True, type=int,
+                        help='Amount to add to each header number in range (may be negative)')
+    parser.add_argument('-s', '--start', type=int,
+                        help='First header image number to shift (default: the first page)')
+    parser.add_argument('-e', '--end', type=int,
+                        help='Last header image number to shift (default: the last page)')
+    parser.add_argument('-p', '--path', default=DEFAULT_OCR_DIR,
+                        help='Directory holding the OCR volume files')
+    parser.add_argument('-n', '--dry-run', action='store_true',
+                        help='Report what would change without writing anything')
+    args = parser.parse_args()
+
+    if not str(args.vol).isnumeric():
+        sys.exit("Volume '{}' is not numeric.".format(args.vol))
+    if args.delta == 0:
+        sys.exit("Delta is 0; nothing to do.")
+
+    filename = 'kama-vol-{}.txt'.format(str(int(args.vol)).zfill(3))
+    filepath = os.path.join(args.path, filename)
+    if not os.path.isfile(filepath):
+        sys.exit("OCR file not found: {}".format(filepath))
+
+    with open(filepath, encoding='utf-8') as f:
+        lines = f.readlines()
+
+    # Use the first tif header as the template for prefix / suffix / pad width.
+    template = next((TIF_RE.match(ln) for ln in lines if TIF_RE.match(ln)), None)
+    if template is None:
+        sys.exit("No 'out_NNNN.tif' header found in {}".format(filepath))
+    prefix, suffix = template.group(1), template.group(3)
+    width = len(template.group(2))
+
+    def make_header(n):
+        return "{}{:0{w}d}{}\n".format(prefix, n, suffix, w=width)
+
+    lo = args.start if args.start is not None else float('-inf')
+    hi = args.end if args.end is not None else float('inf')
+    if args.start is not None and args.end is not None and args.start > args.end:
+        sys.exit("--start {} is greater than --end {}.".format(args.start, args.end))
+
+    changes = []
+    new_nums = []          # every header's resulting number, for the collision check
+    placeholders = []      # non-numeric out_*.tif headers, left untouched
+    in_range = 0
+    for i, line in enumerate(lines):
+        m = TIF_RE.match(line)
+        if not m:
+            if PLACEHOLDER_RE.match(line):
+                placeholders.append((i + 1, line.strip()))
+            continue
+        num = int(m.group(2))
+        if lo <= num <= hi:
+            in_range += 1
+            newnum = num + args.delta
+            if newnum < 0:
+                sys.exit("Delta {} would make header out_{:0{w}d}.tif negative ({}).".format(
+                    args.delta, num, newnum, w=width))
+            new_line = make_header(newnum)
+            if new_line != line:
+                changes.append((i + 1, line.strip(), new_line.strip()))
+            lines[i] = new_line
+            new_nums.append(newnum)
+        else:
+            new_nums.append(num)
+
+    print("File: {}".format(filepath))
+    print("{} {} to headers {}..{}: {} header(s) in range, {} changed.".format(
+        "Adding" if args.delta > 0 else "Subtracting", abs(args.delta),
+        args.start if args.start is not None else "first",
+        args.end if args.end is not None else "last",
+        in_range, len(changes)))
+    for ln, old, new in changes[:8]:
+        print("  line {}: {!r} -> {!r}".format(ln, old, new))
+    if len(changes) > 8:
+        print("  ... and {} more".format(len(changes) - 8))
+
+    # Placeholders (out_XXXX.tif) are skipped automatically -- remind so the
+    # still-unnumbered page doesn't get forgotten.
+    for ln, text in placeholders:
+        print("  (ignored placeholder on line {}: {!r} -- rename it by hand)".format(ln, text))
+
+    # Warn (don't block) if the shift leaves duplicate header numbers -- a sign the
+    # range boundary overlaps the untouched pages and needs a second look.
+    dupes = sorted({n for n in new_nums if new_nums.count(n) > 1})
+    if dupes:
+        print("WARNING: resulting headers contain duplicate number(s): {}".format(
+            ", ".join(str(d) for d in dupes)))
+
+    if not changes:
+        print("Nothing to change.")
+        return
+    if args.dry_run:
+        print("Dry run -- no file written.")
+        return
+
+    bak = backup_path(filepath)
+    shutil.copy(filepath, bak)
+    print("Backup at: {}".format(bak))
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.writelines(lines)
+    print("Wrote: {}".format(filepath))
+
+
+if __name__ == "__main__":
+    main()

--- a/process_volume.py
+++ b/process_volume.py
@@ -127,6 +127,27 @@ def stage_milestoned_files():
     return len(pgd_files)
 
 
+def count_output_milestones():
+    """Tally the milestoned output for the final summary.
+
+    Reads the staged ``*-pgd.txt`` files and returns ``(inserted, pages)`` where
+    ``inserted`` is the number of line milestones (``[p.l]``) actually placed --
+    the same unit as the missed-milestone count -- and ``pages`` is the highest
+    page number seen across page (``[p]``) and line (``[p.l]``) milestones, i.e.
+    the volume's last/total page. Call this while the staged files are still in
+    workspace/stage; add_styles moves them into stage/bak as it runs.
+    """
+    inserted = 0
+    max_page = 0
+    for f in glob.glob(os.path.join(STAGEDIR, '*-pgd.txt')):
+        with open(f, encoding='utf-8') as fh:
+            text = fh.read()
+        inserted += len(re.findall(r'\[\d+\.\d+\]', text))
+        for p in re.findall(r'\[(\d+)(?:\.\d+)?\]', text):
+            max_page = max(max_page, int(p))
+    return inserted, max_page
+
+
 def main(argv):
     args = parse_args(argv)
 
@@ -168,9 +189,14 @@ def main(argv):
         return 0
 
     # --- Stage 2: stage files and run add_styles -------------------------
-    if stage_milestoned_files() == 0:
+    staged = stage_milestoned_files()
+    if staged == 0:
         print("Nothing to style; aborting.")
         return 1
+
+    # Count now, while the staged *-pgd.txt files are still in workspace/stage;
+    # add_styles moves them into stage/bak as it runs.
+    inserted, pages = count_output_milestones()
 
     style_flags = []
     if args.annotations:
@@ -184,7 +210,10 @@ def main(argv):
         print("\nadd_styles2docx.py failed.")
         return 1
 
-    print("\nDone. Styled documents are in {}.".format(OUTDIR))
+    print("\nMilestones inserted and styles added to {} document(s). "
+          "{} total pages. {} out of a total of {} milestones missed.".format(
+              staged, pages, missed, inserted))
+    print("Styled documents are in {}.".format(OUTDIR))
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds a new OCR page-header tool and fixes the completion summary in `process_volume.py`.

### `adjust_ocr_pgnums.py` (new)

The OCR-header analog of `adjust_pg_nums.py` (which shifts `[p.l]` milestones inside a styled Word doc). Adds `-d/--delta` to the image number of every `out_NNNN.tif` header whose current number falls in the `[-s, -e]` range, rewriting the volume in place.

- Builds the file name from `-v` (`kama-vol-NNN.txt`) and looks it up in the OCR dir (`-p` overrides).
- Range is keyed on the headers' **existing** numbers, so `-s 601` means "start at the header currently numbered `out_0601.tif`"; omit `-s`/`-e` for first/last.
- Backs up to `-bak` (timestamped if a backup already exists) before editing; `-n` dry-runs.
- Warns (doesn't block) if the shift leaves duplicate header numbers; refuses a delta that would make a number negative.
- Skips and **reports** non-numeric placeholder headers (`out_XXXX.tif`) — so an unbounded `-s N` won't disturb a page still awaiting its real number, and there's no need to bound with `-e` to protect it.

Unlike `renumber_ocr_pages.py` (absolute — discard the old numbers, stamp a fresh contiguous run), this preserves the existing numbers and only slides the selected window: for when a splice upstream leaves everything from page N off by a constant.

### `process_volume.py` summary fix

The completion summary printed `0 total pages` because it counted the staged `*-pgd.txt` files *after* `add_styles2docx.py` had moved them into `stage/bak`. Now it counts **before** styling, and reports the highest page number as total pages plus the count of inserted line milestones as the total. Example:

```
Milestones inserted and styles added to 3 document(s). 604 total pages. 5 out of a total of 3583 milestones missed.
```

### Docs

`CLAUDE.md` and `README.md` document both scripts and the `out_XXXX.tif` placeholder convention, contrasting `adjust_ocr_pgnums.py` (relative windowed shift) with `renumber_ocr_pages.py` (absolute contiguous renumber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)